### PR TITLE
라인에 대한 정렬과 파일로 저장하는 기능 개발을 완료했습니다.

### DIFF
--- a/src/env_text/mod.rs
+++ b/src/env_text/mod.rs
@@ -2,7 +2,6 @@ pub mod path_args;
 
 use std::collections::HashMap;
 use std::iter::FromIterator;
-use std::iter::IntoIterator::into_iter;
 
 #[derive(Debug)]
 pub struct Element {
@@ -119,7 +118,10 @@ impl EnvText {
         let mut text = String::from("");
 
         if let Some(_parsed_text) = &self.parsed_text {
-            for (key, element) in Vec::from_iter(_parsed_text.iter()).sort_by_key(|a| a.value.line_idx) {
+            let mut parsed_value = Vec::from_iter(_parsed_text.iter());
+            parsed_value.sort_by_key(|element| element.1.line_num);
+
+            for (key, element) in parsed_value {
                 if &key[0..1] == "#" {
                     text = text + &element.value + "\n";
                     continue

--- a/src/env_text/mod.rs
+++ b/src/env_text/mod.rs
@@ -97,7 +97,7 @@ impl EnvText {
     pub fn migrate_from(&mut self, from: &EnvText) -> Result<(), &str> {
         if let (Some(target_map), Some(from_map)) = (&mut self.parsed_text, &from.parsed_text) {
             for (key, element) in from_map {
-                if (key.contains("#")) {
+                if (key[0] == "#") {
                     continue;
                 }
 
@@ -122,12 +122,12 @@ impl EnvText {
         };
     }
 
-    fn stringify(&self) -> Result<&str, &str> {
-        let mut text: &str = "";
+    fn stringify(&self) -> Result<String, &str> {
+        let mut text = String::from("");
         let parsed_text = self.get_parsed_text();
 
         for (key, element) in parsed_text.iter().collect() {
-            writeln!(text, format!("{}={}", key, element.value));
+            writeln!(&mut text, "{}={}", key, element.value)?;
         }
 
         return Ok(text);

--- a/src/env_text/mod.rs
+++ b/src/env_text/mod.rs
@@ -110,4 +110,8 @@ impl EnvText {
             
         return Result::Err("This instance isn't converted yet.");
     }
+
+    pub fn export(&self, path: &str) {
+
+    }
 }

--- a/src/env_text/mod.rs
+++ b/src/env_text/mod.rs
@@ -1,6 +1,5 @@
 pub mod path_args;
 
-use std::iter;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -97,7 +96,7 @@ impl EnvText {
     pub fn migrate_from(&mut self, from: &EnvText) -> Result<(), &str> {
         if let (Some(target_map), Some(from_map)) = (&mut self.parsed_text, &from.parsed_text) {
             for (key, element) in from_map {
-                if (key[0] == "#") {
+                if &key[0..1] == "#" {
                     continue;
                 }
 
@@ -106,7 +105,7 @@ impl EnvText {
                 }
             }
 
-            self.text = String::from(self.stringify()?);
+            self.text = self.stringify()?;
 
             return Ok(());
         } 
@@ -114,23 +113,18 @@ impl EnvText {
         return Result::Err("This instance isn't converted yet.");
     }
 
-    fn get_parsed_text(&self) -> Result<HashMap<String, Element>, &str> {
-        if let Some(_parsed_text) = self.parsed_text {
-            return Ok(_parsed_text)
+    fn stringify(&mut self) -> Result<String, &'static str> {
+        let mut text = String::from("");
+
+        if let Some(_parsed_text) = &self.parsed_text {
+            for (key, element) in _parsed_text {
+                text = text + format!("{}={}\n", &key, &element.value).as_str();
+            }
+    
+            return Ok(text);
         } else {
             return Result::Err("This instance isn't converted yet.");
-        };
-    }
-
-    fn stringify(&self) -> Result<String, &str> {
-        let mut text = String::from("");
-        let parsed_text = self.get_parsed_text();
-
-        for (key, element) in parsed_text.iter().collect() {
-            writeln!(&mut text, "{}={}", key, element.value)?;
-        }
-
-        return Ok(text);
+        };        
     }
 
     pub fn export(&self, path: &str) {

--- a/src/env_text/mod.rs
+++ b/src/env_text/mod.rs
@@ -55,7 +55,7 @@ impl EnvText {
 
             if is_comment {
                 _parsed_text.insert(
-                    String::from(format!("da_cmt_{}", self.comment_idx)), 
+                    String::from(format!("#{}", self.comment_idx)), 
                     Element {
                         value: String::from(text_line),
                         line_num: self.line_idx,
@@ -96,7 +96,7 @@ impl EnvText {
     pub fn migrate_from(&mut self, from: &EnvText) -> Result<(), &str> {
         if let (Some(target_map), Some(from_map)) = (&mut self.parsed_text, &from.parsed_text) {
             for (key, element) in from_map {
-                if (key.contains("da_cmt")) {
+                if (key.contains("#")) {
                     continue;
                 }
 

--- a/src/env_text/mod.rs
+++ b/src/env_text/mod.rs
@@ -1,5 +1,6 @@
 pub mod path_args;
 
+use std::iter;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -105,10 +106,31 @@ impl EnvText {
                 }
             }
 
+            self.text = String::from(self.stringify()?);
+
             return Ok(());
         } 
             
         return Result::Err("This instance isn't converted yet.");
+    }
+
+    fn get_parsed_text(&self) -> Result<HashMap<String, Element>, &str> {
+        if let Some(_parsed_text) = self.parsed_text {
+            return Ok(_parsed_text)
+        } else {
+            return Result::Err("This instance isn't converted yet.");
+        };
+    }
+
+    fn stringify(&self) -> Result<&str, &str> {
+        let mut text: &str = "";
+        let parsed_text = self.get_parsed_text();
+
+        for (key, element) in parsed_text.iter().collect() {
+            writeln!(text, format!("{}={}", key, element.value));
+        }
+
+        return Ok(text);
     }
 
     pub fn export(&self, path: &str) {

--- a/src/env_text/mod.rs
+++ b/src/env_text/mod.rs
@@ -13,7 +13,7 @@ pub struct Element {
 pub struct EnvText {
     comment_idx: usize,
     line_idx: usize,
-    text: String,
+    pub text: String,
     pub parsed_text: Option<HashMap<String, Element>>,
 }
 
@@ -118,6 +118,11 @@ impl EnvText {
 
         if let Some(_parsed_text) = &self.parsed_text {
             for (key, element) in _parsed_text {
+                if &key[0..1] == "#" {
+                    text = text + &element.value + "\n";
+                    continue
+                }
+
                 text = text + format!("{}={}\n", &key, &element.value).as_str();
             }
     

--- a/src/env_text/mod.rs
+++ b/src/env_text/mod.rs
@@ -1,5 +1,8 @@
 pub mod path_args;
 
+use std::io::prelude::*;
+use std::io;
+use std::fs::File;
 use std::collections::HashMap;
 use std::iter::FromIterator;
 
@@ -136,7 +139,10 @@ impl EnvText {
         };        
     }
 
-    pub fn export(&self, path: &str) {
+    pub fn export(&self, path: &str) -> Result<(), io::Error>{
+        let mut buffer = File::create(path)?;
 
+        buffer.write(self.text.as_bytes())?;
+        Ok(())
     }
 }

--- a/src/env_text/mod.rs
+++ b/src/env_text/mod.rs
@@ -1,6 +1,8 @@
 pub mod path_args;
 
 use std::collections::HashMap;
+use std::iter::FromIterator;
+use std::iter::IntoIterator::into_iter;
 
 #[derive(Debug)]
 pub struct Element {
@@ -117,7 +119,7 @@ impl EnvText {
         let mut text = String::from("");
 
         if let Some(_parsed_text) = &self.parsed_text {
-            for (key, element) in _parsed_text {
+            for (key, element) in Vec::from_iter(_parsed_text.iter()).sort_by_key(|a| a.value.line_idx) {
                 if &key[0..1] == "#" {
                     text = text + &element.value + "\n";
                     continue

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ fn main() {
         test1.migrate_from(&test2);
 
         println!("{:?}", test1.text);
+
+        test1.export("test");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,11 @@ fn main() {
 
         test2.parse();
         
-        println!("{:?}", test1.parsed_text);
+        println!("{:?}", test1.text);
 
         test1.migrate_from(&test2);
 
-        println!("{:?}", test1.parsed_text);
+        println!("{:?}", test1.text);
     }
 }
 


### PR DESCRIPTION
# 목표
parsed_text를 라인 순으로 정렬 및 파일로 저장하는 기능을 개발합니다.

# 변경 후

- 이제 stringify시 라인 순서대로 정렬됩니다.
- 이제 파일에 대한 저장 기능 메서드인 `EnvText.export` 기능을 추가했습니다.